### PR TITLE
Security patch: CVE-2024-23331

### DIFF
--- a/Angular/package.json
+++ b/Angular/package.json
@@ -23,6 +23,7 @@
     "angular-auth-oidc-client": "15.0.4",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
+    "vite": "^4.5.2",
     "zone.js": "~0.13.0"
   },
   "devDependencies": {

--- a/Angular/yarn.lock
+++ b/Angular/yarn.lock
@@ -7551,6 +7551,17 @@ vite@4.5.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+vite@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.2.tgz#d6ea8610e099851dad8c7371599969e0f8b97e82"
+  integrity sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==
+  dependencies:
+    esbuild "^0.18.10"
+    postcss "^8.4.27"
+    rollup "^3.27.1"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"


### PR DESCRIPTION
Force vite to ^4.5.2 to address CVE-2024-23331

https://github.com/avanek-trimble/tid-examples/security/dependabot/11